### PR TITLE
Export all public URLs to the environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -229,21 +229,14 @@ func main() {
 			fail("Failed to export BITRISE_PUBLIC_INSTALL_PAGE_URL, error: %s", err)
 		}
 		log.Printf("The public install page url is now available in the Environment Variable: BITRISE_PUBLIC_INSTALL_PAGE_URL (value: %s)", publicInstallPage)
-	}
-
-	if len(publicInstallPages) > 0 {
-		value := strings.Join(publicInstallPages, "|")
-		if err := tools.ExportEnvironmentWithEnvman("BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST", value); err != nil {
-			fail("Failed to export BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST, error: %s", err)
-		}
-		log.Printf("An array of public install page urls is now available in the Environment Variable: BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST (value: %s)", value)
+		log.Printf("")
 	}
 
 	if len(publicInstallPageMap) > 0 {
 		tuples := make([]string, 0)
 
 		for file, url := range publicInstallPageMap {
-			tuples = append(tuples, file + ":" + url)
+			tuples = append(tuples, file + "," + url)
 		}
 
 		value := strings.Join(tuples, "|")
@@ -251,6 +244,7 @@ func main() {
 			fail("Failed to export BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP, error: %s", err)
 		}
 		log.Printf("A map of deployed files and their public install page urls is now available in the Environment Variable: BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP (value: %s)", value)
+		log.Printf("")
 	}
 
 	// --

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-utils/pathutil"
@@ -166,6 +167,8 @@ func main() {
 	log.Infof("Deploying files")
 
 	publicInstallPage := ""
+	publicInstallPages := make([]string,0)
+	publicInstallPageMap := make(map[string]string)
 
 	for _, pth := range clearedFilesToDeploy {
 		ext := filepath.Ext(pth)
@@ -183,6 +186,8 @@ func main() {
 
 			if installPage != "" {
 				publicInstallPage = installPage
+				publicInstallPages = append(publicInstallPages, installPage)
+				publicInstallPageMap[filepath.Base(pth)] = installPage
 			}
 		case ".apk":
 			log.Donef("Uploading apk file: %s", pth)
@@ -194,6 +199,8 @@ func main() {
 
 			if installPage != "" {
 				publicInstallPage = installPage
+				publicInstallPages = append(publicInstallPages, installPage)
+				publicInstallPageMap[filepath.Base(pth)] = installPage
 			}
 		default:
 			log.Donef("Uploading file: %s", pth)
@@ -205,6 +212,8 @@ func main() {
 
 			if installPage != "" {
 				publicInstallPage = installPage
+				publicInstallPages = append(publicInstallPages, installPage)
+				publicInstallPageMap[filepath.Base(pth)] = installPage
 			} else if configs.IsPublicPageEnabled == "true" {
 				log.Warnf("is_enable_public_page is set, but public download isn't allowed for this type of file")
 			}
@@ -221,6 +230,29 @@ func main() {
 		}
 		log.Printf("The public install page url is now available in the Environment Variable: BITRISE_PUBLIC_INSTALL_PAGE_URL (value: %s)", publicInstallPage)
 	}
+
+	if len(publicInstallPages) > 0 {
+		value := strings.Join(publicInstallPages, "|")
+		if err := tools.ExportEnvironmentWithEnvman("BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST", value); err != nil {
+			fail("Failed to export BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST, error: %s", err)
+		}
+		log.Printf("An array of public install page urls is now available in the Environment Variable: BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST (value: %s)", value)
+	}
+
+	if len(publicInstallPageMap) > 0 {
+		tuples := make([]string, 0)
+
+		for file, url := range publicInstallPageMap {
+			tuples = append(tuples, file + ":" + url)
+		}
+
+		value := strings.Join(tuples, "|")
+		if err := tools.ExportEnvironmentWithEnvman("BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP", value); err != nil {
+			fail("Failed to export BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP, error: %s", err)
+		}
+		log.Printf("A map of deployed files and their public install page urls is now available in the Environment Variable: BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP (value: %s)", value)
+	}
+
 	// --
 
 }

--- a/step.yml
+++ b/step.yml
@@ -151,3 +151,16 @@ outputs:
       description: |-
         Public Install Page's URL, if the
         *Enable public page for the App?* option was *enabled*.
+  - BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST:
+    opts:
+      title: List of Public Install Page URLs
+      description: |-
+        An array of pipe-separted (|) Public Install Page URLs, if the
+        *Enable public page for the App?* option was *enabled*.
+  - BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP:
+    opts:
+      title: Map of filenames and Public Install Page URLs
+      description: |-
+        A dictionary of Public Install Page URLs, with the uploaded filename as
+        the key. The format is KEY1:VALUE|KEY2:VALUE
+        Only set if the *Enable public page for the App?* option was *enabled*.


### PR DESCRIPTION
To support workflows where multiple artifacts have an install page, I've had this step export two new environment variables that contain all public URLs, instead of just the last one. The URLs are accessible through:
* a pipe-separated array of URLs, `BITRISE_PUBLIC_INSTALL_PAGE_URL_LIST`
* a map of files and URLS, `BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP.` Entries are separated by pipes (|), keys and values a colon (:)

This fixes #43 and #22 