### PR TITLE
Rename Notify User Group to Notify User Roles

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -40,10 +40,10 @@ inputs:
       is_required: true
   - notify_user_groups: "everyone"
     opts:
-      title: "Notify: User Groups"
+      title: "Notify: User Roles"
       description: |
-        Your App's user groups to notify, comma separated.
-        Possible group names:
+        Your App's user roles to notify, comma separated.
+        Possible role names:
 
         * none
         * testers
@@ -56,7 +56,7 @@ inputs:
 
         `testers, developers`
 
-        If you want to notify everyone in your team just specify `everyone`.
+        If you want to notify everyone in the app's team just specify `everyone`.
 
         If you don't want to notify anyone set this to `none`.
   - notify_email_list:
@@ -76,7 +76,7 @@ inputs:
         with others who are not registered on Bitrise.
 
         **If you disable this option the Notify Emails option will
-        be ignored and the Notify Groups will receive the build's
+        be ignored and the Notify User Roles users will receive the build's
         URL instead of the public page's URL!**
       is_required: true
       is_expand: false


### PR DESCRIPTION
Fixes https://github.com/bitrise-io/steps-deploy-to-bitrise-io/issues/57

Now that we have Organizations and Org Groups it's misleading to call app team roles as Groups IMO. More details: https://github.com/bitrise-io/steps-deploy-to-bitrise-io/issues/57