### PR TITLE
Fix isEnablePublicPage argument in DeployFile

### DIFF
--- a/uploaders/fileuploader.go
+++ b/uploaders/fileuploader.go
@@ -13,7 +13,7 @@ func DeployFile(pth, buildURL, token, notifyUserGroups, notifyEmails, isEnablePu
 		return "", fmt.Errorf("failed to upload file artifact, error: %s", err)
 	}
 
-	publicInstallPage, err := finishArtifact(buildURL, token, artifactID, "", "", "", "no")
+	publicInstallPage, err := finishArtifact(buildURL, token, artifactID, "", "", "", isEnablePublicPage)
 	if err != nil {
 		return "", fmt.Errorf("failed to finish file artifact, error: %s", err)
 	}


### PR DESCRIPTION
## Summary
- fix #73 
- We can get public install page for all type files.