### PR TITLE
chore: Update default bundletool to 1.8.1

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -233,7 +233,7 @@ inputs:
       value_options:
         - "false"
         - "true"
-  - bundletool_version: "0.13.4"
+  - bundletool_version: "1.8.1"
     opts:
       category: Debug
       title: "Bundletool version"


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

Step is using an 18 month old version of bundletool. Also the first URL it tries to download from always fails, resulting in an error being written to the console, but the step continuing without issue.

If nothing else this PR makes sure that new projects created on Bitrise are using a recent stable version of bundletool, in the event that the dev does not explicitly set a version.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
