### PR TITLE
Specify Go version number

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitrise-steplib/steps-deploy-to-bitrise-io
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/bitrise-io/bitrise v0.0.0-20220808135808-3483087dd853


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Specify Go version (1.22.0)

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
There's no Go [1.22 release](https://go.dev/dl/), so the 1.22 directive breaks the step with the following message:
`failed, output: go: downloading go1.22 (darwin/arm64) go: download go1.22 for darwin/arm64: toolchain not available (exit code: 1)`

This solution is suggested on both [StackOverflow](https://stackoverflow.com/a/78643571) and [Reddit](https://www.reddit.com/r/golang/comments/1aukmy7/comment/kr4oc9g/).

### Decisions

<!-- Please list decisions that were made for this change. -->

- Include the patch part of the versioning
