### PR TITLE
[CI-5861] Parse long durations

### DIFF
--- a/test/converters/xcresult3/model3/conversion.go
+++ b/test/converters/xcresult3/model3/conversion.go
@@ -102,9 +102,12 @@ func extractTestCases(nodes []TestNode, fallbackName string) ([]TestCaseWithRetr
 }
 
 func extractDuration(text string) time.Duration {
-	// Duration is in the format "123.456789s" or "123,456789s", so we need to replace the comma with a dot.
-	text = strings.Replace(text, ",", ".", -1)
-	duration, err := time.ParseDuration(text)
+	// Duration is in the format "123.456789s", "123,456789s" or "4m 34s", so we need to do some normalization. We
+	// need to replace the comma with a dot and remove the space to be able to parse it with time.ParseDuration.
+	normalized := strings.ReplaceAll(text, ",", ".")
+	normalized = strings.ReplaceAll(normalized, " ", "")
+
+	duration, err := time.ParseDuration(normalized)
 	if err != nil {
 		return 0
 	}

--- a/test/converters/xcresult3/model3/conversion_test.go
+++ b/test/converters/xcresult3/model3/conversion_test.go
@@ -39,7 +39,7 @@ func TestConversion(t *testing.T) {
 												Type:     TestNodeTypeTestCase,
 												Name:     "TC2",
 												Result:   TestResultFailed,
-												Duration: "1s",
+												Duration: "1m 11s",
 											},
 										},
 									},
@@ -108,7 +108,7 @@ func TestConversion(t *testing.T) {
 												TestCase: TestCase{
 													Name:      "TC2",
 													ClassName: "TS1",
-													Time:      1 * time.Second,
+													Time:      71 * time.Second,
 													Result:    "Failed",
 												},
 											},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

When tests take a really long time to run the xcresult data extract will contain them in the "Xm Xs" (like 4m 34s) format.