### PR TITLE
Route zero-length files to single-shot upload

### DIFF
--- a/uploaders/uploader.go
+++ b/uploaders/uploader.go
@@ -43,7 +43,11 @@ func (u *Uploader) Wait() {
 }
 
 func (u *Uploader) upload(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, item *deployment.DeployableItem, buildArtifactMeta *AppDeploymentMetaData) ([]ArtifactURLs, error) {
-	if u.useMultipartUpload {
+	// Empty files always go through the single-shot path: a multipart upload
+	// needs at least one part with content, so a zero-byte file has no valid
+	// part layout (the backend still issues one part URL, which the part-count
+	// check would reject).
+	if u.useMultipartUpload && artifact.FileSize > 0 {
 		return u.uploadMultipart(buildURL, token, artifact, artifactType, contentType, item, buildArtifactMeta)
 	}
 	return u.uploadSingle(buildURL, token, artifact, artifactType, contentType, item, buildArtifactMeta)


### PR DESCRIPTION
## Summary

A zero-byte file fails in multipart upload mode with:

```
part_urls count (1) does not match expected (0) for file size 0 and part size ...
```

`ceil(0 / partSize)` is **0** expected parts, but the backend (correctly) hands back **1** part URL, so the part-count check rejects it. Non-empty files are unaffected (even 1 byte ceils to 1 part).

## Fix

Route empty files through the single-shot path — which already handles empty bodies (`nil` request body, `Content-Length: 0`) — even when multipart upload is enabled. A zero-byte file has no valid multipart part layout, so single-shot is the correct mechanism.

## Test plan

- `go build ./...` passes.
- Reproduced against a local fake artifact server: a zero-length file failed before the change and uploads successfully after (routed to single-shot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)