### PR TITLE
Make the xcresult test cases runnable locally

### DIFF
--- a/test/converters_test.go
+++ b/test/converters_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const sampleArtifactsGitURL = "https://github.com/bitrise-io/sample-artifacts.git"
+
 func TestXCresult3Converters(t *testing.T) {
 	// xcresulttool renders attachment timestamps in the process timezone; the expected reports are UTC.
 	t.Setenv("TZ", "UTC")
@@ -179,9 +181,8 @@ func TestXCresult3Converters(t *testing.T) {
 
 	_, b, _, _ := runtime.Caller(0)
 	testPackageDir := filepath.Dir(b)
-	projectRootDir := filepath.Dir(testPackageDir)
 
-	multiLevelUITestsXCResult := resolveSampleArtifact(t, projectRootDir, "xcresults/xcresult3_multi_level_UI_tests.xcresult")
+	multiLevelUITestsXCResult := resolveSampleArtifact(t, "xcresults/xcresult3_multi_level_UI_tests.xcresult")
 
 	for _, test := range []struct {
 		name          string
@@ -263,9 +264,11 @@ func TestXCresult3Converters(t *testing.T) {
 // _tmp checkout the _download_sample_artifacts CI workflow creates when the fixture is present, and
 // otherwise clones into that same _tmp dir, so local runs share one checkout with CI and re-cloning
 // is avoided across runs.
-func resolveSampleArtifact(t *testing.T, projectRootDir, relPath string) string {
+func resolveSampleArtifact(t *testing.T, relPath string) string {
 	t.Helper()
 
+	_, thisFile, _, _ := runtime.Caller(0)
+	projectRootDir := filepath.Dir(filepath.Dir(thisFile))
 	tmpDir := filepath.Join(projectRootDir, "_tmp")
 	artifactPath := filepath.Join(tmpDir, relPath)
 	if dirExists(artifactPath) {
@@ -273,7 +276,7 @@ func resolveSampleArtifact(t *testing.T, projectRootDir, relPath string) string 
 	}
 
 	require.NoError(t, os.RemoveAll(tmpDir))
-	cmd := command.NewFactory(env.NewRepository()).Create("git", []string{"clone", "--depth", "1", "https://github.com/bitrise-io/sample-artifacts.git", tmpDir}, nil)
+	cmd := command.NewFactory(env.NewRepository()).Create("git", []string{"clone", "--depth", "1", sampleArtifactsGitURL, tmpDir}, nil)
 	require.NoError(t, cmd.Run())
 
 	return artifactPath

--- a/test/converters_test.go
+++ b/test/converters_test.go
@@ -1,19 +1,24 @@
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"testing"
 
-	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-steputils/v2/testreport"
+	"github.com/bitrise-io/go-utils/log"
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-xcode/v2/testresult/xcresult3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func TestXCresult3Converters(t *testing.T) {
+	// xcresulttool renders attachment timestamps in the process timezone; the expected reports are UTC.
+	t.Setenv("TZ", "UTC")
 	log.SetEnableDebugLog(true)
 	want := testreport.TestReport{
 		TestSuites: []testreport.TestSuite{
@@ -176,6 +181,8 @@ func TestXCresult3Converters(t *testing.T) {
 	testPackageDir := filepath.Dir(b)
 	projectRootDir := filepath.Dir(testPackageDir)
 
+	multiLevelUITestsXCResult := resolveSampleArtifact(t, projectRootDir, "xcresults/xcresult3_multi_level_UI_tests.xcresult")
+
 	for _, test := range []struct {
 		name          string
 		converter     testreport.Converter
@@ -187,7 +194,7 @@ func TestXCresult3Converters(t *testing.T) {
 		{
 			name:          "xcresult3",
 			converter:     xcresult3.NewConverter(false),
-			testFilePaths: []string{filepath.Join(projectRootDir, "_tmp/xcresults/xcresult3_multi_level_UI_tests.xcresult")},
+			testFilePaths: []string{multiLevelUITestsXCResult},
 			wantDetect:    true,
 			wantXMLError:  false,
 			wantXML:       want,
@@ -250,4 +257,29 @@ func TestXCresult3Converters(t *testing.T) {
 			}
 		})
 	}
+}
+
+// resolveSampleArtifact returns a path to a fixture from the sample-artifacts repo. It reuses the
+// _tmp checkout the _download_sample_artifacts CI workflow creates when the fixture is present, and
+// otherwise clones into that same _tmp dir, so local runs share one checkout with CI and re-cloning
+// is avoided across runs.
+func resolveSampleArtifact(t *testing.T, projectRootDir, relPath string) string {
+	t.Helper()
+
+	tmpDir := filepath.Join(projectRootDir, "_tmp")
+	artifactPath := filepath.Join(tmpDir, relPath)
+	if dirExists(artifactPath) {
+		return artifactPath
+	}
+
+	require.NoError(t, os.RemoveAll(tmpDir))
+	cmd := command.NewFactory(env.NewRepository()).Create("git", []string{"clone", "--depth", "1", "https://github.com/bitrise-io/sample-artifacts.git", tmpDir}, nil)
+	require.NoError(t, cmd.Run())
+
+	return artifactPath
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -287,17 +287,10 @@ func Test_ParseXctest3Results(t *testing.T) {
 	// xcresulttool renders attachment timestamps in the process timezone; the golden is UTC.
 	t.Setenv("TZ", "UTC")
 	tmpDir := t.TempDir()
-	gitDir := path.Join(tmpDir, "git")
-
-	// The xcresult3 format has many small encoded binary files, so it is better to use a real xcresult file.
-	// We are storing these in the sample-artifacts git repo.
-	cmd := command.NewFactory(env.NewRepository()).Create("git", []string{"clone", "--depth", "1", "https://github.com/bitrise-io/sample-artifacts.git", gitDir}, nil)
-	err := cmd.Run()
-	require.NoError(t, err)
 
 	testDir := path.Join(tmpDir, "tests")
 	testResultDir := path.Join(testDir, "test-result")
-	err = os.MkdirAll(testDir, os.ModePerm)
+	err := os.MkdirAll(testDir, os.ModePerm)
 	require.NoError(t, err)
 
 	phaseDir := path.Join(testResultDir, "phase")
@@ -311,7 +304,7 @@ func Test_ParseXctest3Results(t *testing.T) {
 		t.Fatal("failed to create dummy files in dir, error:", err)
 	}
 
-	oldDir := path.Join(gitDir, "xcresults", "xcresult3-device-configuration-tests.xcresult")
+	oldDir := resolveSampleArtifact(t, "xcresults/xcresult3-device-configuration-tests.xcresult")
 	newDir := path.Join(phaseDir, "xcresult3-device-configuration-tests.xcresult")
 	copyCmd := command.NewFactory(env.NewRepository()).Create("cp", []string{"-a", oldDir, newDir}, nil)
 	err = copyCmd.Run()

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -284,6 +284,8 @@ func Test_ParseXctestResults(t *testing.T) {
 }
 
 func Test_ParseXctest3Results(t *testing.T) {
+	// xcresulttool renders attachment timestamps in the process timezone; the golden is UTC.
+	t.Setenv("TZ", "UTC")
 	tmpDir := t.TempDir()
 	gitDir := path.Join(tmpDir, "git")
 


### PR DESCRIPTION
## Problem
Two tests in the `test` package only passed on CI, and failed on a bare local `go test ./...`:

1. **Timezone.** `Test_ParseXctest3Results` and `TestXCresult3Converters` compare generated reports whose attachment names contain timestamps rendered by `xcresulttool` in the process timezone (e.g. `... at 12.28.29 PM`). The expected data is UTC, so both failed off-UTC machines with a shifted hour.
2. **Fixture provisioning.** `TestXCresult3Converters` reads its xcresult from `_tmp`, which only the `_download_sample_artifacts` workflow populates, so it failed locally with `Detect` returning false.

Both are green on CI only because CI runs in UTC and provisions `_tmp` first.

## Fix
- Pin `TZ=UTC` in both tests via `t.Setenv`; the `xcresulttool` subprocess inherits it, matching the UTC expectations.
- Resolve the converter fixture via a helper that reuses the `_tmp` checkout when present and otherwise clones sample-artifacts into that same `_tmp` dir, so a bare `go test` needs no setup and does not re-clone across runs.

## Testing
`go test ./...` is green locally. Both tests pass under `TZ=America/New_York` and `TZ=Europe/Budapest`, which failed before.