### PR TITLE
Log status code, URL, and response body on failed artifact create requests

### DIFF
--- a/uploaders/upload_multipart.go
+++ b/uploaders/upload_multipart.go
@@ -152,7 +152,7 @@ func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, arti
 
 		response, err = http.DefaultClient.Do(req)
 		if err != nil {
-			return fmt.Errorf("failed to perform create artifact request, error: %s", err)
+			return fmt.Errorf("failed to perform create artifact request (%s), error: %s", uri, err)
 		}
 
 		defer func() {
@@ -175,8 +175,8 @@ func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, arti
 				ErrorMessage string `json:"error_msg"`
 			}
 			var createResponse errorResponse
-			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr != nil {
-				return errors.New(string(body))
+			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr != nil || createResponse.ErrorMessage == "" {
+				return fmt.Errorf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
 			}
 
 			return errors.New(createResponse.ErrorMessage)

--- a/uploaders/upload_multipart.go
+++ b/uploaders/upload_multipart.go
@@ -175,11 +175,12 @@ func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, arti
 				ErrorMessage string `json:"error_msg"`
 			}
 			var createResponse errorResponse
-			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr != nil || createResponse.ErrorMessage == "" {
-				return fmt.Errorf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
+			errMsg := fmt.Sprintf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
+			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr == nil && createResponse.ErrorMessage != "" {
+				errMsg = createResponse.ErrorMessage
 			}
 
-			return errors.New(createResponse.ErrorMessage)
+			return errors.New(errMsg)
 		}
 
 		if err := json.Unmarshal(body, &uploadTasks); err != nil {

--- a/uploaders/upload_single.go
+++ b/uploaders/upload_single.go
@@ -136,11 +136,12 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 				ErrorMessage string `json:"error_msg"`
 			}
 			var createResponse errorResponse
-			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr != nil || createResponse.ErrorMessage == "" {
-				return fmt.Errorf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
+			errMsg := fmt.Sprintf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
+			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr == nil && createResponse.ErrorMessage != "" {
+				errMsg = createResponse.ErrorMessage
 			}
 
-			return errors.New(createResponse.ErrorMessage)
+			return errors.New(errMsg)
 		}
 
 		if err := json.Unmarshal(body, &uploadTasks); err != nil {

--- a/uploaders/upload_single.go
+++ b/uploaders/upload_single.go
@@ -118,7 +118,7 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 		}
 		response, err = http.PostForm(uri, data)
 		if err != nil {
-			return fmt.Errorf("failed to perform create artifact request, error: %s", err)
+			return fmt.Errorf("failed to perform create artifact request (%s), error: %s", uri, err)
 		}
 
 		defer func() {
@@ -136,8 +136,8 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 				ErrorMessage string `json:"error_msg"`
 			}
 			var createResponse errorResponse
-			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr != nil {
-				return errors.New(string(body))
+			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr != nil || createResponse.ErrorMessage == "" {
+				return fmt.Errorf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
 			}
 
 			return errors.New(createResponse.ErrorMessage)


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Context

We had an incident where a failed artifact upload logged an empty error message, giving us no way to diagnose the failure:

```
failed file deploy:
  failed to create artifact (/tmp/snapshot3554133073/src.zip):

deploy failed, error:
  failed file deploy:
    failed to create artifact (/tmp/snapshot3554133073/src.zip):
```

### Changes

- In `createArtifact` (`upload_single.go`) and `createMultipartArtifact` (`upload_multipart.go`), when the create-artifact request returns a non-200 response whose body doesn't contain a (non-empty) `error_msg` field, fall back to an error that includes the HTTP status code, request URL, and raw response body instead of an empty string.
- Include the request URL in the "failed to perform create artifact request" error as well, so connection-level failures (e.g. a malformed/unreachable URL) are identifiable.

### Investigation details

Root cause: `errors.New(createResponse.ErrorMessage)` returned an error with an empty `Error()` string whenever the server's JSON error response didn't populate `error_msg` (or parsed successfully but with an empty value). This error propagated unchanged through all the `%w`-wrapped errors up to the top-level deploy failure message, producing the truncated log seen in the incident.

### Decisions

This is a minimal, targeted fix for the specific swallowed-error case. A broader follow-up is planned to migrate the upload retry logic in `upload_single.go`/`upload_multipart.go` onto the shared retry HTTP client already used elsewhere in this repo (`report/api/api.go`, `test/test.go`), to unify retry/error-logging behavior across all upload paths.