### PR TITLE
Use shared http retry and logger helpers

### DIFF
--- a/report/api/api.go
+++ b/report/api/api.go
@@ -30,8 +30,12 @@ type HTTPClient interface {
 type TestReportClient struct {
 	logger     log.Logger
 	httpClient HTTPClient
-	buildURL   string
-	authToken  string
+	// artifactClient is a second, separate retrying HTTP client (uploaders.HTTPClient) used only
+	// for UploadAsset, because uploaders.UploadArtifact requires this concrete type.
+	// perform() below should eventually be migrated onto artifactClient so this client only needs one retrying HTTP stack.
+	artifactClient *uploaders.HTTPClient
+	buildURL       string
+	authToken      string
 }
 
 // NewBitriseClient ...
@@ -39,10 +43,11 @@ func NewBitriseClient(buildURL, authToken string, logger log.Logger) *TestReport
 	httpClient := retry.NewHTTPClient().StandardClient()
 
 	return &TestReportClient{
-		logger:     logger,
-		httpClient: httpClient,
-		buildURL:   buildURL,
-		authToken:  authToken,
+		logger:         logger,
+		httpClient:     httpClient,
+		artifactClient: uploaders.NewHTTPClient(logger),
+		buildURL:       buildURL,
+		authToken:      authToken,
 	}
 }
 
@@ -88,7 +93,7 @@ func (t *TestReportClient) UploadAsset(url, path, contentType string) error {
 		Path:     path,
 		FileSize: fileInfo.Size(),
 	}
-	_, err = uploaders.UploadArtifact(url, artifact, contentType)
+	_, err = uploaders.UploadArtifact(url, artifact, contentType, t.artifactClient)
 	return err
 }
 

--- a/uploaders/common_test.go
+++ b/uploaders/common_test.go
@@ -101,7 +101,7 @@ func Test_uploadArtifact(t *testing.T) {
 				Path:     tt.artifactPth,
 				FileSize: fileInfo.Size(),
 			}
-			if _, err := UploadArtifact(tt.uploadURL, artifact, tt.contentType); (err != nil) != tt.wantErr {
+			if _, err := UploadArtifact(tt.uploadURL, artifact, tt.contentType, NewHTTPClient(logV2.NewLogger())); (err != nil) != tt.wantErr {
 				t.Errorf("UploadArtifact() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -124,7 +124,7 @@ func Test_uploadPart(t *testing.T) {
 	}))
 	defer server.Close()
 
-	etag, err := uploadPart(server.URL, filePath, 25, 50, 1, logV2.NewLogger())
+	etag, err := uploadPart(server.URL, filePath, 25, 50, 1, NewHTTPClient(logV2.NewLogger()))
 
 	require.NoError(t, err)
 	require.Equal(t, `"test-etag"`, etag)
@@ -156,7 +156,7 @@ func Test_uploadAllParts(t *testing.T) {
 		}))
 		defer server.Close()
 
-		parts, err := uploadAllParts(filePath, 100, 50, []string{server.URL, server.URL}, 2, logV2.NewLogger())
+		parts, err := uploadAllParts(filePath, 100, 50, []string{server.URL, server.URL}, 2, NewHTTPClient(logV2.NewLogger()))
 
 		require.NoError(t, err)
 		require.Len(t, parts, 2)
@@ -179,7 +179,7 @@ func Test_uploadAllParts(t *testing.T) {
 		}))
 		defer server.Close()
 
-		parts, err := uploadAllParts(filePath, 101, 51, []string{server.URL, server.URL}, 2, logV2.NewLogger())
+		parts, err := uploadAllParts(filePath, 101, 51, []string{server.URL, server.URL}, 2, NewHTTPClient(logV2.NewLogger()))
 
 		require.NoError(t, err)
 		require.Len(t, parts, 2)
@@ -190,7 +190,7 @@ func Test_uploadAllParts(t *testing.T) {
 	t.Run("rejects zero part size", func(t *testing.T) {
 		filePath := writeTempFile(t, []byte("x"))
 
-		_, err := uploadAllParts(filePath, 1, 0, []string{"http://unused"}, 1, logV2.NewLogger())
+		_, err := uploadAllParts(filePath, 1, 0, []string{"http://unused"}, 1, NewHTTPClient(logV2.NewLogger()))
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid part size")
@@ -200,7 +200,7 @@ func Test_uploadAllParts(t *testing.T) {
 		filePath := writeTempFile(t, make([]byte, 100))
 
 		// 100 bytes / 50-byte parts → 2 parts expected, but we pass 3 URLs
-		_, err := uploadAllParts(filePath, 100, 50, []string{"http://a", "http://b", "http://c"}, 1, logV2.NewLogger())
+		_, err := uploadAllParts(filePath, 100, 50, []string{"http://a", "http://b", "http://c"}, 1, NewHTTPClient(logV2.NewLogger()))
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "does not match expected")

--- a/uploaders/httpclient.go
+++ b/uploaders/httpclient.go
@@ -1,0 +1,100 @@
+package uploaders
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	logV2 "github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/retryhttp"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+const maxDebugDumpBodyBytes = 64 * 1024
+
+// maxResponseBodyBytes bounds how much of a response body we'll ever buffer into memory.
+// All expected responses (JSON task lists, upload acks) are well under this; it exists to
+// stop a misbehaving endpoint (e.g. a proxy error page) from being read without limit.
+const maxResponseBodyBytes = 10 * 1024 * 1024
+
+type HTTPClient struct {
+	logger logV2.Logger
+	client *retryablehttp.Client
+}
+
+func NewHTTPClient(logger logV2.Logger) *HTTPClient {
+	h := &HTTPClient{logger: logger}
+
+	client := retryhttp.NewClient(logger)
+	client.RetryMax = 2
+	client.RetryWaitMin = 5 * time.Second
+	client.RetryWaitMax = 5 * time.Second
+	client.RequestLogHook = h.logRequest
+	client.ResponseLogHook = h.logResponse
+	h.client = client
+
+	return h
+}
+
+func (h *HTTPClient) logRequest(_ retryablehttp.Logger, req *http.Request, retryNumber int) {
+	if retryNumber > 0 {
+		h.logger.Warnf("%d attempt failed, retrying: %s %s", retryNumber, req.Method, req.URL)
+	}
+
+	if req.ContentLength < 0 || req.ContentLength > maxDebugDumpBodyBytes {
+		h.logger.Debugf("request: %s %s (body omitted, %d bytes)", req.Method, req.URL, req.ContentLength)
+		return
+	}
+	if dump, err := httputil.DumpRequestOut(req, true); err == nil {
+		h.logger.Debugf("request:\n%s", dump)
+	}
+}
+
+func (h *HTTPClient) logResponse(_ retryablehttp.Logger, resp *http.Response) {
+	// Response bodies here are always small (JSON or an empty upload ack), so always safe to dump.
+	if dump, err := httputil.DumpResponse(resp, true); err == nil {
+		h.logger.Debugf("response:\n%s", dump)
+	}
+}
+
+func (h *HTTPClient) doFormRequest(method, uri string, data url.Values) ([]byte, error) {
+	req, err := retryablehttp.NewRequest(method, uri, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request (%s): %s", uri, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return h.doRequest(req)
+}
+
+func (h *HTTPClient) doRequest(req *retryablehttp.Request) ([]byte, error) {
+	_, body, err := h.doRequestWithResponse(req)
+	return body, err
+}
+
+func (h *HTTPClient) doRequestWithResponse(req *retryablehttp.Request) (*http.Response, []byte, error) {
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to perform request (%s), error: %s", req.URL, err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			h.logger.Warnf("Failed to close response body, error: %s", err)
+		}
+	}()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read response body (%s), error: %s", req.URL, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return resp, body, fmt.Errorf("non success status code: %d, url: %s, body: %s", resp.StatusCode, req.URL, body)
+	}
+
+	return resp, body, nil
+}

--- a/uploaders/upload_multipart.go
+++ b/uploaders/upload_multipart.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -16,11 +15,9 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/bitrise-io/go-utils/log"
-	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/urlutil"
-	logV2 "github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
 )
 
@@ -43,7 +40,7 @@ type UploadedPart struct {
 }
 
 func (u *Uploader) uploadMultipart(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, item *deployment.DeployableItem, buildArtifactMeta *AppDeploymentMetaData) ([]ArtifactURLs, error) {
-	tasks, err := createMultipartArtifact(buildURL, token, artifact, artifactType, contentType, item.ArchiveAsArtifact, item.IntermediateFileMeta, u.logger)
+	tasks, err := createMultipartArtifact(buildURL, token, artifact, artifactType, contentType, item.ArchiveAsArtifact, item.IntermediateFileMeta, u.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create artifact (%s): %w", artifact.Path, err)
 	}
@@ -58,7 +55,7 @@ func (u *Uploader) uploadMultipart(buildURL, token string, artifact ArtifactArgs
 	var artifactURLs []ArtifactURLs
 	for _, task := range tasks {
 		start := time.Now()
-		parts, uploadErr := uploadAllParts(artifact.Path, artifact.FileSize, task.PartSize, task.PartURLs, u.multipartConcurrency, u.logger)
+		parts, uploadErr := uploadAllParts(artifact.Path, artifact.FileSize, task.PartSize, task.PartURLs, u.multipartConcurrency, u.httpClient)
 
 		transferType := Artifact
 		if task.IsIntermediate {
@@ -77,13 +74,13 @@ func (u *Uploader) uploadMultipart(buildURL, token string, artifact ArtifactArgs
 		u.tracker.logFileTransfer(transferType, details, uploadErr, item.ArchiveAsArtifact, item.IsIntermediateFile())
 
 		if uploadErr != nil {
-			if _, abortErr := finishMultipartArtifact(buildURL, token, task.Identifier(), false, nil, nil, u.logger); abortErr != nil {
+			if _, abortErr := finishMultipartArtifact(buildURL, token, task.Identifier(), false, nil, nil, u.httpClient); abortErr != nil {
 				u.logger.Warnf("Failed to abort multipart upload for artifact %d: %s", task.ID, abortErr)
 			}
 			return nil, fmt.Errorf("failed to upload artifact parts (%s): %w", artifact.Path, uploadErr)
 		}
 
-		urls, err := finishMultipartArtifact(buildURL, token, task.Identifier(), true, parts, buildArtifactMeta, u.logger)
+		urls, err := finishMultipartArtifact(buildURL, token, task.Identifier(), true, parts, buildArtifactMeta, u.httpClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to finish artifact upload (%s): %w", artifact.Path, err)
 		}
@@ -96,10 +93,10 @@ func (u *Uploader) uploadMultipart(buildURL, token string, artifact ArtifactArgs
 	return artifactURLs, nil
 }
 
-func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, logger logV2.Logger) ([]MultipartUploadTask, error) {
+func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, httpClient *HTTPClient) ([]MultipartUploadTask, error) {
 	artifactName := filepath.Base(artifact.Path)
 
-	log.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
+	httpClient.logger.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
 
 	if strings.TrimSpace(token) == "" {
 		return nil, fmt.Errorf("provided API token is empty")
@@ -132,83 +129,40 @@ func createMultipartArtifact(buildURL, token string, artifact ArtifactArgs, arti
 		return nil, fmt.Errorf("failed to generate create artifact url, error: %s", err)
 	}
 
-	var response *http.Response
-	var uploadTasks []MultipartUploadTask
-
-	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
-		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
+	body, err := httpClient.doFormRequest(http.MethodPost, uri, data)
+	if err != nil {
+		type errorResponse struct {
+			ErrorMessage string `json:"error_msg"`
 		}
-
-		req, err := http.NewRequest(http.MethodPost, uri, strings.NewReader(data.Encode()))
-		if err != nil {
-			return fmt.Errorf("failed to create request: %s", err)
+		var createResponse errorResponse
+		if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr == nil && createResponse.ErrorMessage != "" {
+			return nil, errors.New(createResponse.ErrorMessage)
 		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-		if dump, dumpErr := httputil.DumpRequestOut(req, true); dumpErr == nil {
-			logger.Debugf("create_multipart_upload request:\n%s", dump)
-		}
-
-		response, err = http.DefaultClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to perform create artifact request (%s), error: %s", uri, err)
-		}
-
-		defer func() {
-			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
-			}
-		}()
-
-		if dump, dumpErr := httputil.DumpResponse(response, true); dumpErr == nil {
-			logger.Debugf("create_multipart_upload response:\n%s", dump)
-		}
-
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read create artifact response, error: %s", err)
-		}
-
-		if response.StatusCode != http.StatusOK {
-			type errorResponse struct {
-				ErrorMessage string `json:"error_msg"`
-			}
-			var createResponse errorResponse
-			errMsg := fmt.Sprintf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
-			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr == nil && createResponse.ErrorMessage != "" {
-				errMsg = createResponse.ErrorMessage
-			}
-
-			return errors.New(errMsg)
-		}
-
-		if err := json.Unmarshal(body, &uploadTasks); err != nil {
-			return fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
-		}
-
-		if len(uploadTasks) == 0 {
-			return fmt.Errorf("failed to create artifact on bitrise, error: no upload task received")
-		}
-
-		for _, task := range uploadTasks {
-			if len(task.PartURLs) == 0 {
-				return fmt.Errorf("failed to create artifact on bitrise, error: missing part urls")
-			}
-			if task.ID == 0 {
-				return fmt.Errorf("failed to create artifact on bitrise, error: missing artifact id")
-			}
-		}
-
-		return nil
-	}); err != nil {
 		return nil, err
+	}
+
+	var uploadTasks []MultipartUploadTask
+	if err := json.Unmarshal(body, &uploadTasks); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
+	}
+
+	if len(uploadTasks) == 0 {
+		return nil, fmt.Errorf("failed to create artifact on bitrise, error: no upload task received")
+	}
+
+	for _, task := range uploadTasks {
+		if len(task.PartURLs) == 0 {
+			return nil, fmt.Errorf("failed to create artifact on bitrise, error: missing part urls")
+		}
+		if task.ID == 0 {
+			return nil, fmt.Errorf("failed to create artifact on bitrise, error: missing artifact id")
+		}
 	}
 
 	return uploadTasks, nil
 }
 
-func finishMultipartArtifact(buildURL, token, artifactID string, success bool, parts []UploadedPart, appDeploymentMeta *AppDeploymentMetaData, logger logV2.Logger) (ArtifactURLs, error) {
+func finishMultipartArtifact(buildURL, token, artifactID string, success bool, parts []UploadedPart, appDeploymentMeta *AppDeploymentMetaData, httpClient *HTTPClient) (ArtifactURLs, error) {
 	data := url.Values{
 		"api_token": {token},
 		"success":   {strconv.FormatBool(success)},
@@ -270,7 +224,16 @@ func finishMultipartArtifact(buildURL, token, artifactID string, success bool, p
 	}
 	encodedBody := data.Encode() + partsEncoded.String()
 
-	var response *http.Response
+	req, err := retryablehttp.NewRequest(http.MethodPost, uri, strings.NewReader(encodedBody))
+	if err != nil {
+		return ArtifactURLs{}, fmt.Errorf("failed to create request (%s): %s", uri, err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	body, err := httpClient.doRequest(req)
+	if err != nil {
+		return ArtifactURLs{}, err
+	}
 
 	type finishArtifactResponse struct {
 		PublicInstallPageURL string   `json:"public_install_page_url"`
@@ -280,55 +243,12 @@ func finishMultipartArtifact(buildURL, token, artifactID string, success bool, p
 	}
 
 	var artifactResponse finishArtifactResponse
-	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
-		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
-		}
-
-		req, err := http.NewRequest(http.MethodPost, uri, strings.NewReader(encodedBody))
-		if err != nil {
-			return fmt.Errorf("failed to create request: %s", err)
-		}
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-		if dump, dumpErr := httputil.DumpRequestOut(req, true); dumpErr == nil {
-			logger.Debugf("finish_multipart_upload request:\n%s", dump)
-		}
-
-		response, err = http.DefaultClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to perform finish artifact request, error: %s", err)
-		}
-		defer func() {
-			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
-			}
-		}()
-
-		if dump, dumpErr := httputil.DumpResponse(response, true); dumpErr == nil {
-			logger.Debugf("finish_multipart_upload response:\n%s", dump)
-		}
-
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read finish artifact response, error: %s", err)
-		}
-
-		if response.StatusCode != http.StatusOK {
-			return fmt.Errorf("failed to create artifact on bitrise, status code: %d, response: %s", response.StatusCode, string(body))
-		}
-
-		if err := json.Unmarshal(body, &artifactResponse); err != nil {
-			return fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
-		}
-
-		return nil
-	}); err != nil {
-		return ArtifactURLs{}, err
+	if err := json.Unmarshal(body, &artifactResponse); err != nil {
+		return ArtifactURLs{}, fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
 	}
 
 	if len(artifactResponse.InvalidEmails) > 0 {
-		log.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
+		httpClient.logger.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
 	}
 
 	return ArtifactURLs{
@@ -341,75 +261,44 @@ func finishMultipartArtifact(buildURL, token, artifactID string, success bool, p
 // uploadPart uploads a single chunk of a file to a presigned S3 part URL.
 // It opens the file independently to allow concurrent calls without seeking conflicts.
 // Returns the ETag header value which must be included in the finish call.
-func uploadPart(partURL, filePath string, offset, size int64, partNumber int, logger logV2.Logger) (string, error) {
-	netClient := &http.Client{Timeout: 10 * time.Minute}
-
-	var etag string
-
-	err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
-		if attempt > 0 {
-			log.Warnf("part %d: attempt %d failed, retrying", partNumber, attempt)
+func uploadPart(partURL, filePath string, offset, size int64, partNumber int, httpClient *HTTPClient) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %s", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			httpClient.logger.Warnf("failed to close file: %s", err)
 		}
+	}()
 
-		file, err := os.Open(filePath)
-		if err != nil {
-			return fmt.Errorf("failed to open file: %s", err)
-		}
-		defer func() {
-			if err := file.Close(); err != nil {
-				log.Warnf("failed to close file: %s", err)
-			}
-		}()
+	// SectionReader provides a bounded, independently seekable view into the file,
+	// safe for concurrent use since each goroutine opens its own file descriptor.
+	section := io.NewSectionReader(file, offset, size)
 
-		// SectionReader provides a bounded, independently seekable view into the file,
-		// safe for concurrent use since each goroutine opens its own file descriptor.
-		section := io.NewSectionReader(file, offset, size)
+	req, err := retryablehttp.NewRequest(http.MethodPut, partURL, section)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %s", err)
+	}
+	req.ContentLength = size
 
-		req, err := http.NewRequest(http.MethodPut, partURL, section)
-		if err != nil {
-			return fmt.Errorf("failed to create request: %s", err)
-		}
-		req.ContentLength = size
+	resp, _, err := httpClient.doRequestWithResponse(req)
+	if err != nil {
+		return "", fmt.Errorf("part %d: %w", partNumber, err)
+	}
 
-		logger.Debugf("part %d upload: PUT %s (offset=%d size=%d)", partNumber, partURL, offset, size)
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		return "", fmt.Errorf("part %d: response missing ETag header", partNumber)
+	}
 
-		resp, err := netClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("failed to upload part %d: %s", partNumber, err)
-		}
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				log.Errorf("Failed to close response body, error: %s", err)
-			}
-		}()
-
-		if dump, dumpErr := httputil.DumpResponse(resp, true); dumpErr == nil {
-			logger.Debugf("part %d response:\n%s", partNumber, dump)
-		}
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read response body: %s", err)
-		}
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("part %d: non-200 status %d: %s", partNumber, resp.StatusCode, body)
-		}
-
-		etag = resp.Header.Get("ETag")
-		if etag == "" {
-			return fmt.Errorf("part %d: response missing ETag header", partNumber)
-		}
-
-		return nil
-	})
-
-	return etag, err
+	return etag, nil
 }
 
 // uploadAllParts uploads the file in partSize-byte chunks, one per partURL, up to
 // concurrency parts at a time. The last part is trimmed to the file's
 // remaining bytes. Returns the ETags required by the finish call.
-func uploadAllParts(filePath string, fileSize int64, partSize int64, partURLs []string, concurrency int, logger logV2.Logger) ([]UploadedPart, error) {
+func uploadAllParts(filePath string, fileSize int64, partSize int64, partURLs []string, concurrency int, httpClient *HTTPClient) ([]UploadedPart, error) {
 	if partSize <= 0 {
 		return nil, fmt.Errorf("invalid part size %d", partSize)
 	}
@@ -442,7 +331,7 @@ func uploadAllParts(filePath string, fileSize int64, partSize int64, partURLs []
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			etag, err := uploadPart(url, filePath, offset, size, partNumber, logger)
+			etag, err := uploadPart(url, filePath, offset, size, partNumber, httpClient)
 			results <- partResult{partNumber: partNumber, etag: etag, err: err}
 		}()
 	}

--- a/uploaders/upload_single.go
+++ b/uploaders/upload_single.go
@@ -1,11 +1,9 @@
 package uploaders
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,9 +13,8 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/hashicorp/go-retryablehttp"
 
-	"github.com/bitrise-io/go-utils/log"
-	"github.com/bitrise-io/go-utils/retry"
 	"github.com/bitrise-io/go-utils/urlutil"
 	"github.com/bitrise-steplib/steps-deploy-to-bitrise-io/deployment"
 )
@@ -34,7 +31,7 @@ func (u UploadTask) Identifier() string {
 }
 
 func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, item *deployment.DeployableItem, buildArtifactMeta *AppDeploymentMetaData) ([]ArtifactURLs, error) {
-	tasks, err := createArtifact(buildURL, token, artifact, artifactType, contentType, item.ArchiveAsArtifact, item.IntermediateFileMeta)
+	tasks, err := createArtifact(buildURL, token, artifact, artifactType, contentType, item.ArchiveAsArtifact, item.IntermediateFileMeta, u.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create artifact (%s): %w", artifact.Path, err)
 	}
@@ -48,7 +45,7 @@ func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, a
 
 	var artifactURLs []ArtifactURLs
 	for _, task := range tasks {
-		details, uploadErr := UploadArtifact(task.URL, artifact, contentType)
+		details, uploadErr := UploadArtifact(task.URL, artifact, contentType, u.httpClient)
 
 		transferType := Artifact
 		if task.IsIntermediate {
@@ -60,7 +57,7 @@ func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, a
 			return nil, fmt.Errorf("failed to upload artifact (%s): %w", artifact.Path, uploadErr)
 		}
 
-		urls, err := finishArtifact(buildURL, token, task.Identifier(), buildArtifactMeta)
+		urls, err := finishArtifact(buildURL, token, task.Identifier(), buildArtifactMeta, u.httpClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to finish artifact upload (%s): %w", artifact.Path, err)
 		}
@@ -73,11 +70,11 @@ func (u *Uploader) uploadSingle(buildURL, token string, artifact ArtifactArgs, a
 	return artifactURLs, nil
 }
 
-func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData) ([]UploadTask, error) {
+func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType, contentType string, archiveAsArtifact bool, pipelineMeta *deployment.IntermediateFileMetaData, httpClient *HTTPClient) ([]UploadTask, error) {
 	// create form data
 	artifactName := filepath.Base(artifact.Path)
 
-	log.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
+	httpClient.logger.Printf("file size: %s", units.BytesSize(float64(artifact.FileSize)))
 
 	if strings.TrimSpace(token) == "" {
 		return nil, fmt.Errorf("provided API token is empty")
@@ -109,132 +106,73 @@ func createArtifact(buildURL, token string, artifact ArtifactArgs, artifactType,
 		return nil, fmt.Errorf("failed to generate create artifact url, error: %s", err)
 	}
 
-	var response *http.Response
-	var uploadTasks []UploadTask
-
-	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
-		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
+	body, err := httpClient.doFormRequest(http.MethodPost, uri, data)
+	if err != nil {
+		type errorResponse struct {
+			ErrorMessage string `json:"error_msg"`
 		}
-		response, err = http.PostForm(uri, data)
-		if err != nil {
-			return fmt.Errorf("failed to perform create artifact request (%s), error: %s", uri, err)
+		var createResponse errorResponse
+		if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr == nil && createResponse.ErrorMessage != "" {
+			return nil, errors.New(createResponse.ErrorMessage)
 		}
-
-		defer func() {
-			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
-			}
-		}()
-
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read create artifact response, error: %s", err)
-		}
-		if response.StatusCode != http.StatusOK {
-			type errorResponse struct {
-				ErrorMessage string `json:"error_msg"`
-			}
-			var createResponse errorResponse
-			errMsg := fmt.Sprintf("non success status code: %d, url: %s, body: %s", response.StatusCode, uri, body)
-			if unmarshalErr := json.Unmarshal(body, &createResponse); unmarshalErr == nil && createResponse.ErrorMessage != "" {
-				errMsg = createResponse.ErrorMessage
-			}
-
-			return errors.New(errMsg)
-		}
-
-		if err := json.Unmarshal(body, &uploadTasks); err != nil {
-			return fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
-		}
-
-		if len(uploadTasks) == 0 {
-			return fmt.Errorf("failed to create artifact on bitrise, error: no upload task received")
-		}
-
-		for _, task := range uploadTasks {
-			if task.ErrorMessage != "" {
-				return fmt.Errorf("failed to create artifact on bitrise, error message: %s", task.ErrorMessage)
-			}
-
-			if task.URL == "" {
-				return fmt.Errorf("failed to create artifact on bitrise, error: missing upload url")
-			}
-			if task.ID == 0 {
-				return fmt.Errorf("failed to create artifact on bitrise, error: missing artifact id")
-			}
-		}
-
-		return nil
-	}); err != nil {
 		return nil, err
+	}
+
+	var uploadTasks []UploadTask
+	if err := json.Unmarshal(body, &uploadTasks); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
+	}
+
+	if len(uploadTasks) == 0 {
+		return nil, fmt.Errorf("failed to create artifact on bitrise, error: no upload task received")
+	}
+
+	for _, task := range uploadTasks {
+		if task.ErrorMessage != "" {
+			return nil, fmt.Errorf("failed to create artifact on bitrise, error message: %s", task.ErrorMessage)
+		}
+
+		if task.URL == "" {
+			return nil, fmt.Errorf("failed to create artifact on bitrise, error: missing upload url")
+		}
+		if task.ID == 0 {
+			return nil, fmt.Errorf("failed to create artifact on bitrise, error: missing artifact id")
+		}
 	}
 
 	return uploadTasks, nil
 }
 
-func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string) (TransferDetails, error) {
-	netClient := &http.Client{
-		Timeout: 10 * time.Minute,
-	}
-
+func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string, httpClient *HTTPClient) (TransferDetails, error) {
 	start := time.Now()
 
-	err := retry.Times(3).Wait(5).Try(func(attempt uint) error {
+	// Initializes request body to nil to send a Content-Length of 0: https://github.com/golang/go/issues/20257#issuecomment-299509391
+	var rawBody any
+	if artifact.FileSize > 0 {
 		file, err := os.Open(artifact.Path)
 		if err != nil {
-			return fmt.Errorf("failed to open artifact, error: %s", err)
+			return TransferDetails{}, fmt.Errorf("failed to open artifact, error: %s", err)
 		}
 		defer func() {
 			if err := file.Close(); err != nil {
-				log.Warnf("failed to close file, error: %s", err)
+				httpClient.logger.Warnf("failed to close file, error: %s", err)
 			}
 		}()
+		rawBody = file
+	}
 
-		// Initializes request body to nil to send a Content-Length of 0: https://github.com/golang/go/issues/20257#issuecomment-299509391
-		var reqBody io.Reader
-		if artifact.FileSize > 0 {
-			reqBody = io.NopCloser(file)
-		}
+	req, err := retryablehttp.NewRequest(http.MethodPut, uploadURL, rawBody)
+	if err != nil {
+		return TransferDetails{}, fmt.Errorf("failed to create request, error: %s", err)
+	}
 
-		request, err := http.NewRequest(http.MethodPut, uploadURL, reqBody)
-		if err != nil {
-			return fmt.Errorf("failed to create request, error: %s", err)
-		}
+	if contentType != "" {
+		req.Header.Add("Content-Type", contentType)
+	}
+	req.Header.Add("X-Upload-Content-Length", strconv.FormatInt(artifact.FileSize, 10)) // header used by Google Cloud Storage signed URLs
+	req.ContentLength = artifact.FileSize
 
-		if contentType != "" {
-			request.Header.Add("Content-Type", contentType)
-		}
-
-		request.Header.Add("X-Upload-Content-Length", strconv.FormatInt(artifact.FileSize, 10)) // header used by Google Cloud Storage signed URLs
-		request.ContentLength = artifact.FileSize
-
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer cancel()
-		request = request.WithContext(ctx)
-
-		resp, err := netClient.Do(request)
-		if err != nil {
-			return fmt.Errorf("failed to upload artifact, error: %s", err)
-		}
-
-		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				log.Errorf("Failed to close response body, error: %s", err)
-			}
-		}()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read response body, error: %s", err)
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("non success status code: %d, headers: %s, body: %s", resp.StatusCode, resp.Header, body)
-		}
-
-		return nil
-	})
+	_, err = httpClient.doRequest(req)
 
 	details := TransferDetails{
 		Size:     artifact.FileSize,
@@ -245,7 +183,7 @@ func UploadArtifact(uploadURL string, artifact ArtifactArgs, contentType string)
 	return details, err
 }
 
-func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDeploymentMetaData) (ArtifactURLs, error) {
+func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDeploymentMetaData, httpClient *HTTPClient) (ArtifactURLs, error) {
 	// create form data
 	data := url.Values{"api_token": {token}}
 	if appDeploymentMeta != nil {
@@ -288,8 +226,6 @@ func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDe
 		return ArtifactURLs{}, fmt.Errorf("failed to generate finish artifact url, error: %s", err)
 	}
 
-	var response *http.Response
-
 	type finishArtifactResponse struct {
 		PublicInstallPageURL string   `json:"public_install_page_url"`
 		PermanentDownloadURL string   `json:"permanent_download_url"`
@@ -297,41 +233,18 @@ func finishArtifact(buildURL, token, artifactID string, appDeploymentMeta *AppDe
 		InvalidEmails        []string `json:"invalid_emails"`
 	}
 
-	var artifactResponse finishArtifactResponse
-	if err := retry.Times(3).Wait(5 * time.Second).Try(func(attempt uint) error {
-		if attempt > 0 {
-			log.Warnf("%d attempt failed", attempt)
-		}
-		response, err = http.PostForm(uri, data)
-		if err != nil {
-			return fmt.Errorf("failed to perform finish artifact request, error: %s", err)
-		}
-		defer func() {
-			if err := response.Body.Close(); err != nil {
-				log.Errorf("Failed to close reponse body, error: %s", err)
-			}
-		}()
-
-		// process response
-		body, err := io.ReadAll(response.Body)
-		if err != nil {
-			return fmt.Errorf("failed to read finish artifact response, error: %s", err)
-		}
-		if response.StatusCode != http.StatusOK {
-			return fmt.Errorf("failed to create artifact on bitrise, status code: %d, response: %s", response.StatusCode, string(body))
-		}
-
-		if err := json.Unmarshal(body, &artifactResponse); err != nil {
-			return fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
-		}
-
-		return nil
-	}); err != nil {
+	body, err := httpClient.doFormRequest(http.MethodPost, uri, data)
+	if err != nil {
 		return ArtifactURLs{}, err
 	}
 
+	var artifactResponse finishArtifactResponse
+	if err := json.Unmarshal(body, &artifactResponse); err != nil {
+		return ArtifactURLs{}, fmt.Errorf("failed to unmarshal response (%s), error: %s", string(body), err)
+	}
+
 	if len(artifactResponse.InvalidEmails) > 0 {
-		log.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
+		httpClient.logger.Warnf("Invalid e-mail addresses: %s", strings.Join(artifactResponse.InvalidEmails, ", "))
 	}
 
 	return ArtifactURLs{

--- a/uploaders/uploader.go
+++ b/uploaders/uploader.go
@@ -20,6 +20,7 @@ import (
 
 type Uploader struct {
 	logger               log.Logger
+	httpClient           *HTTPClient
 	fileManager          fileutil.FileManager
 	androidParser        *androidparser.Parser
 	iosParser            *iosparser.Parser
@@ -38,6 +39,7 @@ func New(
 ) *Uploader {
 	return &Uploader{
 		logger:               logger,
+		httpClient:           NewHTTPClient(logger),
 		fileManager:          fileManager,
 		androidParser:        androidParser,
 		iosParser:            iosParser,

--- a/uploaders/uploader_test.go
+++ b/uploaders/uploader_test.go
@@ -17,6 +17,7 @@ func newTestUploader(t *testing.T, useMultipart bool) *Uploader {
 	logger := logV2.NewLogger()
 	return &Uploader{
 		logger:               logger,
+		httpClient:           NewHTTPClient(logger),
 		tracker:              newTracker(env.NewRepository(), logger),
 		useMultipartUpload:   useMultipart,
 		multipartConcurrency: 1,


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *PATCH* [version update](https://semver.org/)

### Status

Draft, waiting for other refactors and migrations to be merged.

### Context

Follow-up to #267. That PR fixed one specific spot where a failed upload logged an empty error message; this PR addresses the underlying cause — `upload_single.go` and `upload_multipart.go` each hand-rolled their own retry loop (`retry.Times().Wait().Try()`), HTTP client, and error/logging handling, so fixes and improvements had to be made in multiple, slightly different places.

### Changes

- Added `uploaders/httpclient.go`: an `HTTPClient` struct wrapping the shared `go-utils/v2/retryhttp` retryable client (the same one already used by `report/api/api.go` and `test/test.go`), with:
  - Consistent retry behavior (3 attempts total, 5s wait — matching the previous behavior) with a warning logged on each retry.
  - A consistent failure error format including the HTTP status code, request URL, and response body.
  - Request/response dumping at debug level, skipping the request body dump for large payloads (file/part upload PUTs) to avoid buffering hundreds of MiB just to log it.
  - A 10 MiB cap on how much of a response body is ever read into memory, to guard against an unexpectedly large response from a misbehaving endpoint.
- Migrated `createArtifact`, `UploadArtifact`, `finishArtifact` (`upload_single.go`) and `createMultipartArtifact`, `finishMultipartArtifact`, `uploadPart` (`upload_multipart.go`) onto this shared client, removing 3 divergent retry/HTTP implementations and the last usages of the v1 `go-utils/retry` and `go-utils/log` packages in these files.
- `Uploader` now holds one `HTTPClient` (built once in `New()`) instead of each call constructing its own retryable client per request.
- `report/api/api.go`'s `TestReportClient` also builds and reuses one `HTTPClient` (`artifactClient`) for `UploadAsset`, since `uploaders.UploadArtifact`'s signature now requires it.

### Investigation details

Considered folding `TestReportClient.perform()` (used by `CreateReport`/`FinishReport`) onto the same shared client too, since it currently uses a separate v1 `retry.NewHTTPClient()` client with its own hand-rolled request/response dumping and error parsing. Left that out of scope here to keep the diff focused on the upload path — `artifactClient` and `httpClient` coexisting in `TestReportClient` is flagged with a comment as a known follow-up.

Also looked at whether `go-utils/v2/httputil`'s `PrintRequest`/`PrintResponse` could replace our own request/response dump helpers. It's a good fit in principle, but (a) it always dumps the full body unconditionally with no size guard, and (b) it isn't available at the `go-utils/v2` version currently pinned in `go.mod` (`v2.0.0-alpha.34`; the package was added in `alpha.35`). Not worth a dependency bump for this alone.

### Decisions

- Kept `TestReportClient.httpClient` (v1) and `TestReportClient.artifactClient` (v2) as two separate retrying HTTP clients in `report/api/api.go` for now, rather than unifying them in this PR.